### PR TITLE
 Fix Null Pointer error

### DIFF
--- a/src/main/java/hudson/plugins/openstf/STFBuildWrapper.java
+++ b/src/main/java/hudson/plugins/openstf/STFBuildWrapper.java
@@ -368,8 +368,10 @@ public class STFBuildWrapper extends BuildWrapper {
         String lineSeparator =
             Computer.currentComputer().getSystemProperties().get("line.separator").toString();
         for (String line: devicesResult.split(lineSeparator)) {
-          if (line.contains(remote.serial()) && line.contains("device")) {
-            return true;
+          if (line != null) {
+            if (line.contains(remote.serial()) && line.contains("device")) {
+              return true;
+            }
           }
         }
 


### PR DESCRIPTION
Sometimes a Null Pointer error occurs when reading the result of "adb devices" command execution, so put a null check.