### PR TITLE
 [Experimental] Add support for reserving multiple devices

### DIFF
--- a/src/main/java/hudson/plugins/openstf/AndroidRemoteContext.java
+++ b/src/main/java/hudson/plugins/openstf/AndroidRemoteContext.java
@@ -19,6 +19,8 @@ import org.jvnet.hudson.plugins.port_allocator.PortAllocationManager;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.List;
+import java.util.ArrayList;
 
 public class AndroidRemoteContext {
   /** Interval during which an emulator command should complete. */
@@ -28,12 +30,12 @@ public class AndroidRemoteContext {
   protected static final int PORT_RANGE_END = 9999;
 
   private int adbServerPort;
-  protected String serial;
+  protected List<String> serial;
 
   protected PortAllocationManager portAllocator;
 
   private AndroidSdk sdk;
-  private DeviceListResponseDevices stfDevice = null;
+  private List<DeviceListResponseDevices> stfDevice = null;
 
   protected AbstractBuild<?, ?> build;
   private BuildListener listener;
@@ -46,6 +48,8 @@ public class AndroidRemoteContext {
     this.listener = listener;
     this.launcher = launcher;
     this.sdk = sdk;
+    this.serial = new ArrayList<String>();
+    this.stfDevice = new ArrayList<DeviceListResponseDevices>();
 
     final Computer computer = Computer.currentComputer();
 
@@ -65,7 +69,7 @@ public class AndroidRemoteContext {
     return adbServerPort;
   }
 
-  public String serial() {
+  public List<String> getSerial() {
     return serial;
   }
 
@@ -148,12 +152,12 @@ public class AndroidRemoteContext {
     return getProcStarter(Utils.getToolCommand(sdk, launcher.isUnix(), new SdkCliCommand( tool, args)));
   }
 
-  public DeviceListResponseDevices getDevice() {
+  public List<DeviceListResponseDevices> getDevice() {
     return stfDevice;
   }
 
   public void setDevice(DeviceListResponseDevices device) {
-    stfDevice = device;
-    serial = device.remoteConnectUrl;
+    stfDevice.add(device);
+    serial.add(device.remoteConnectUrl);
   }
 }

--- a/src/main/java/hudson/plugins/openstf/DeviceLogger.java
+++ b/src/main/java/hudson/plugins/openstf/DeviceLogger.java
@@ -1,0 +1,61 @@
+package hudson.plugins.openstf;
+
+import hudson.FilePath;
+import hudson.Proc;
+import hudson.plugins.android_emulator.sdk.Tool;
+import hudson.util.NullStream;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class DeviceLogger{
+    public FilePath logcatFile;
+    public OutputStream logcatStream;
+    public String logcatArgs;
+    public Proc logWriter;
+
+    public DeviceLogger(AndroidRemoteContext remote, String remoteDeviceSerial, FilePath workspace){
+        try{
+            this.logcatFile = workspace.createTextTempFile("logcat_" + remoteDeviceSerial, ".log", "", false);
+        } catch (java.io.IOException|java.lang.InterruptedException ex) {
+            this.logcatFile = null;
+        }
+
+        try{
+            if (this.logcatFile != null){
+                this.logcatStream  = this.logcatFile.write();
+            } else {this.logcatStream  = null;}
+        } catch (java.io.IOException|java.lang.InterruptedException ex) {
+            this.logcatStream = null;
+        }
+
+        this.logcatArgs = String.format("-s %s logcat -v time", remoteDeviceSerial);
+
+        try{
+            if (this.logcatStream != null){
+            this.logWriter = remote.getToolProcStarter(Tool.ADB, this.logcatArgs)
+                .stdout(this.logcatStream).stderr(new NullStream()).start();
+            }
+            else{this.logWriter = null;}
+        } catch (java.io.IOException|java.lang.InterruptedException ex) {
+            this.logWriter = null;
+        }
+    }
+
+    public FilePath getLogcatFile(){
+        return this.logcatFile;
+    }
+
+    public OutputStream getLogcatSteam(){
+        return this.logcatStream;
+    }
+
+    public String getLogcatArgs() {
+        return this.logcatArgs;
+    }
+
+    public Proc getLogWriter(){
+        return this.logWriter;
+    }
+
+}

--- a/src/main/java/hudson/plugins/openstf/STFBuildWrapper.java
+++ b/src/main/java/hudson/plugins/openstf/STFBuildWrapper.java
@@ -46,6 +46,7 @@ import java.io.PrintStream;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
 
 public class STFBuildWrapper extends BuildWrapper {
 
@@ -60,6 +61,8 @@ public class STFBuildWrapper extends BuildWrapper {
 
   public JSONObject deviceCondition;
   public final int deviceReleaseWaitTime;
+  public final boolean enableRemoteAccessToAllFilteredDevices;
+  public final List<DeviceLogger> DevicesLoggerArray;
 
   /**
    * Allocates a STFBuildWrapper object.
@@ -67,9 +70,11 @@ public class STFBuildWrapper extends BuildWrapper {
    * @param deviceReleaseWaitTime Waiting-time for the STF device to be released
    */
   @DataBoundConstructor
-  public STFBuildWrapper(JSONObject deviceCondition, int deviceReleaseWaitTime) {
+  public STFBuildWrapper(JSONObject deviceCondition, int deviceReleaseWaitTime, boolean enableRemoteAccessToAllFilteredDevices) {
     this.deviceCondition = deviceCondition;
     this.deviceReleaseWaitTime = deviceReleaseWaitTime;
+    this.enableRemoteAccessToAllFilteredDevices = enableRemoteAccessToAllFilteredDevices;
+    this.DevicesLoggerArray = new ArrayList<DeviceLogger>();
   }
 
   @Override
@@ -145,9 +150,8 @@ public class STFBuildWrapper extends BuildWrapper {
         androidSdk.hasKnownRoot()
             ? androidSdk.getSdkRoot() : hudson.plugins.android_emulator.Messages.USING_PATH();
     log(logger, hudson.plugins.android_emulator.Messages.USING_SDK(displayHome));
-
     STFConfig stfConfig = new STFConfig(useSpecificKey, adbPublicKey, adbPrivateKey,
-        deviceFilter, deviceReleaseWaitTime);
+        deviceFilter, deviceReleaseWaitTime, this.enableRemoteAccessToAllFilteredDevices);
 
     return doSetup(build, launcher, listener, androidSdk, stfConfig);
   }
@@ -162,18 +166,21 @@ public class STFBuildWrapper extends BuildWrapper {
         new AndroidRemoteContext(build, launcher, listener, androidSdk);
 
     try {
-      String reservedDeviceId = stfConfig.reserve();
-      DeviceListResponseDevices device = Utils.getSTFDeviceById(reservedDeviceId);
-      remote.setDevice(device);
-      log(logger, Messages.SHOW_RESERVED_DEVICE_INFO(device.name, device.serial,
-          device.sdk, device.version));
-      build.addAction(new STFReservedDeviceAction(descriptor.stfApiEndpoint, device));
-    } catch (STFException ex) {
-      log(logger, ex.getMessage());
-      build.setResult(Result.NOT_BUILT);
-      if (remote.getDevice() != null) {
-        cleanUp(stfConfig, remote);
+      List<DeviceListResponseDevices>  reservedDevices = stfConfig.reserve();
+      log(logger, Messages.SHOW_TOTAL_RESERVED_AMOUNT_OF_DEVICES(Integer.toString(reservedDevices.size())));
+      for (DeviceListResponseDevices device: reservedDevices){
+        DeviceListResponseDevices reservedJobDevice = Utils.getSTFDeviceById(device.serial);
+        remote.setDevice(reservedJobDevice);
+        log(logger, Messages.SHOW_RESERVED_DEVICE_INFO(reservedJobDevice.name, reservedJobDevice.serial,
+            reservedJobDevice.sdk, reservedJobDevice.version));
+        build.addAction(new STFReservedDeviceAction(descriptor.stfApiEndpoint, reservedJobDevice));
       }
+    } catch (STFException ex) {
+          log(logger, ex.getMessage());
+          build.setResult(Result.NOT_BUILT);
+          if (remote.getDevice().size() != 0) {
+            cleanUp(stfConfig, remote);
+          }
       return null;
     }
 
@@ -207,14 +214,15 @@ public class STFBuildWrapper extends BuildWrapper {
       cleanUp(stfConfig, remote);
       return null;
     }
-    final FilePath logcatFile = workspace.createTextTempFile("logcat_", ".log", "", false);
-    final OutputStream logcatStream = logcatFile.write();
-    final String logcatArgs = String.format("-s %s logcat -v time", remote.serial());
-    final Proc logWriter = remote.getToolProcStarter(Tool.ADB, logcatArgs)
-        .stdout(logcatStream).stderr(new NullStream()).start();
+
+    for (DeviceListResponseDevices device: remote.getDevice()) {
+        DevicesLoggerArray.add(new DeviceLogger(remote, device.remoteConnectUrl, workspace));
+    }
 
     // Make sure we're still connected
-    connect(remote);
+    for (DeviceListResponseDevices device: remote.getDevice()){
+        connect(remote, device.remoteConnectUrl);
+    }
 
     log(logger, Messages.WAITING_FOR_STF_DEVICE_CONNECT_COMPLETION());
     int connectTimeout = STF_DEVICE_CONNECT_COMPLETE_TIMEOUT_MS;
@@ -233,10 +241,16 @@ public class STFBuildWrapper extends BuildWrapper {
     return new Environment() {
       @Override
       public void buildEnvVars(Map<String, String> env) {
-        env.put("ANDROID_SERIAL", remote.serial());
-        env.put("ANDROID_AVD_DEVICE", remote.serial());
-        env.put("ANDROID_ADB_SERVER_PORT", Integer.toString(remote.adbServerPort()));
-        env.put("ANDROID_TMP_LOGCAT_FILE", logcatFile.getRemote());
+        for (DeviceListResponseDevices device: remote.getDevice()) {
+            env.put("ANDROID_SERIAL", device.remoteConnectUrl);
+            env.put("ANDROID_AVD_DEVICE", device.remoteConnectUrl);
+            env.put("ANDROID_ADB_SERVER_PORT", Integer.toString(remote.adbServerPort()));
+            break;
+        }
+        for (int i =0 ; i < DevicesLoggerArray.size(); i++) {
+            env.put("ANDROID_TMP_LOGCAT_FILE", DevicesLoggerArray.get(i).getLogcatFile().getRemote());
+            break;
+        }
         if (androidSdk.hasKnownRoot()) {
           env.put("JENKINS_ANDROID_HOME", androidSdk.getSdkRoot());
           env.put("ANDROID_HOME", androidSdk.getSdkRoot());
@@ -252,24 +266,24 @@ public class STFBuildWrapper extends BuildWrapper {
       public boolean tearDown(AbstractBuild build, BuildListener listener)
           throws IOException, InterruptedException {
 
-        cleanUp(stfConfig, remote, logWriter, logcatFile, logcatStream, artifactsDir);
+        cleanUp(stfConfig, remote, DevicesLoggerArray, artifactsDir);
         return true;
       }
     };
   }
 
-  private static void connect(AndroidRemoteContext remote)
+  private static void connect(AndroidRemoteContext remote, String remote_serial)
       throws IOException, InterruptedException {
 
     ArgumentListBuilder adbConnectCmd = remote
-        .getToolCommand(Tool.ADB, "connect " + remote.serial());
+        .getToolCommand(Tool.ADB, "connect " + remote_serial);
     remote.getProcStarter(adbConnectCmd).start()
         .joinWithTimeout(5L, TimeUnit.SECONDS, remote.launcher().getListener());
   }
 
-  private static void disconnect(AndroidRemoteContext remote)
+  private static void disconnect(AndroidRemoteContext remote, String remote_serial)
       throws IOException, InterruptedException {
-    final String args = "disconnect " + remote.serial();
+    final String args = "disconnect " + remote_serial;
     ArgumentListBuilder adbDisconnectCmd = remote.getToolCommand(Tool.ADB, args);
     remote.getProcStarter(adbDisconnectCmd).start()
         .joinWithTimeout(5L, TimeUnit.SECONDS, remote.launcher().getListener());
@@ -277,46 +291,53 @@ public class STFBuildWrapper extends BuildWrapper {
 
   private void cleanUp(STFConfig stfConfig, AndroidRemoteContext remote)
     throws IOException, InterruptedException {
-    cleanUp(stfConfig, remote, null, null, null, null);
+    cleanUp(stfConfig, remote, new ArrayList<DeviceLogger>(), null);
   }
 
-  private void cleanUp(STFConfig stfConfig, AndroidRemoteContext remote, Proc logcatProcess,
-      FilePath logcatFile, OutputStream logcatStream, File artifactsDir)
+  private void cleanUp(STFConfig stfConfig, AndroidRemoteContext remote, List<DeviceLogger> DevicesLoggerArray,
+   File artifactsDir)
       throws IOException, InterruptedException {
 
     // Disconnect STF device from adb
-    disconnect(remote);
+
+    for (DeviceListResponseDevices device: remote.getDevice()){
+        disconnect(remote, device.remoteConnectUrl);
+    }
 
     try {
-      stfConfig.release(remote.getDevice());
+      for (DeviceListResponseDevices device: remote.getDevice())
+      stfConfig.release(device);
     } catch (STFException ex) {
       log(remote.logger(), ex.getMessage());
     }
 
     // Clean up logging process
-    if (logcatProcess != null) {
-      if (logcatProcess.isAlive()) {
-        // This should have stopped when the emulator was,
-        // but if not attempt to kill the process manually.
-        // First, give it a final chance to finish cleanly.
-        Thread.sleep(3 * 1000);
-        if (logcatProcess.isAlive()) {
-          hudson.plugins.android_emulator.util.Utils
-              .killProcess(logcatProcess, KILL_PROCESS_TIMEOUT_MS);
-        }
-      }
-      try {
-        logcatStream.close();
-      } catch (Exception ex) {
-        // ignore
-      }
+    for( int i=0; i < DevicesLoggerArray.size(); i++){
 
-      // Archive the logs
-      if (logcatFile.length() != 0) {
-        log(remote.logger(), hudson.plugins.android_emulator.Messages.ARCHIVING_LOG());
-        logcatFile.copyTo(new FilePath(artifactsDir).child("logcat.txt"));
-      }
-      logcatFile.delete();
+        if (DevicesLoggerArray.get(i).getLogWriter() != null) {
+          if (DevicesLoggerArray.get(i).getLogWriter().isAlive()) {
+            // This should have stopped when the emulator was,
+            // but if not attempt to kill the process manually.
+            // First, give it a final chance to finish cleanly.
+            Thread.sleep(3 * 1000);
+            if (DevicesLoggerArray.get(i).getLogWriter().isAlive()) {
+              hudson.plugins.android_emulator.util.Utils
+                  .killProcess(DevicesLoggerArray.get(i).getLogWriter(), KILL_PROCESS_TIMEOUT_MS);
+            }
+          }
+              try {
+            DevicesLoggerArray.get(i).logcatStream.close();
+          } catch (Exception ex) {
+            // ignore
+          }
+
+          // Archive the logs
+          if (DevicesLoggerArray.get(i).getLogcatFile().length() != 0) {
+            log(remote.logger(), hudson.plugins.android_emulator.Messages.ARCHIVING_LOG());
+            DevicesLoggerArray.get(i).getLogcatFile().copyTo(new FilePath(artifactsDir).child(DevicesLoggerArray.get(i).getLogcatFile().getName()));
+          }
+          DevicesLoggerArray.get(i).getLogcatFile().delete();
+        }
     }
 
     ArgumentListBuilder adbKillCmd = remote.getToolCommand(Tool.ADB, "kill-server");
@@ -363,18 +384,21 @@ public class STFBuildWrapper extends BuildWrapper {
             Computer.currentComputer().getSystemProperties().get("line.separator").toString();
         for (String line: devicesResult.split(lineSeparator)) {
           if (line != null) {
-            if (line.contains(remote.serial()) && line.contains("device")) {
-              return true;
-            }
+              for (DeviceListResponseDevices device: remote.getDevice()){
 
-            if (line.contains(remote.serial()) && line.contains("unauthorized")) {
-                unauthorized++;
-
-                //Show without rising exception, that we can't authorize device
-                if (unauthorized == 4 && !shownUnauthorizedOnce) {
-                    log(remote.logger(), Messages.DEVICE_UNAUTHORIZED());
-                    shownUnauthorizedOnce=true;
+                if (line.contains(device.remoteConnectUrl) && line.contains("device")) {
+                  return true;
                 }
+
+                if (line.contains(device.remoteConnectUrl) && line.contains("unauthorized")) {
+                    unauthorized++;
+
+                    //Show without rising exception, that we can't authorize device
+                    if (unauthorized == 4 && !shownUnauthorizedOnce) {
+                        log(remote.logger(), Messages.DEVICE_UNAUTHORIZED());
+                        shownUnauthorizedOnce=true;
+                    }
+              }
             }
           }
         }
@@ -430,6 +454,7 @@ public class STFBuildWrapper extends BuildWrapper {
     @Override
     public BuildWrapper newInstance(StaplerRequest req, JSONObject formData) throws FormException {
       int deviceReleaseWaitTime = 0;
+      Boolean enableRemoteAccessToAllFilteredDevices = false;
       JSONObject deviceCondition = new JSONObject();
 
       try {
@@ -441,6 +466,14 @@ public class STFBuildWrapper extends BuildWrapper {
         // ignore
       } finally {
         formData.discard("deviceReleaseWaitTime");
+      }
+
+      try {
+        enableRemoteAccessToAllFilteredDevices = Boolean.valueOf(formData.getString("enableRemoteAccessToAllFilteredDevices"));
+      } catch (NumberFormatException ex) {
+        // ignore
+      } finally {
+        formData.discard("enableRemoteAccessToAllFilteredDevices");
       }
 
       JSONArray conditionArray = formData.optJSONArray("condition");
@@ -458,7 +491,7 @@ public class STFBuildWrapper extends BuildWrapper {
         }
       }
 
-      return new STFBuildWrapper(deviceCondition, deviceReleaseWaitTime);
+      return new STFBuildWrapper(deviceCondition, deviceReleaseWaitTime, enableRemoteAccessToAllFilteredDevices);
     }
 
     @Override

--- a/src/main/resources/hudson/plugins/openstf/Messages.properties
+++ b/src/main/resources/hudson/plugins/openstf/Messages.properties
@@ -29,6 +29,7 @@ CANNOT_GET_WORKSPACE_ON_THIS_BUILD=Could not get workspace directory on this bui
 INTERRUPTED_DURING_STF_DEVICE_CONNECT_COMPLETION=Interrupted while waiting for the connection to the STF device to complete
 COULD_NOT_CHECK_STF_DEVICE_CONNECT_COMPLETION=Could not check for the STF device connect completion
 DEVICE_UNAUTHORIZED=Please check is adbkey.pub is set for selected provider at STF.
+SHOW_TOTAL_RESERVED_AMOUNT_OF_DEVICES=Amount of Reserved Devices: {0}
 
 # Publish
 

--- a/src/main/resources/hudson/plugins/openstf/STFBuildWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/openstf/STFBuildWrapper/config.jelly
@@ -39,6 +39,9 @@
                   <f:entry title="${%Wait time for a device to be released[min]}">
                     <f:number name="open-stf.deviceReleaseWaitTime" value="${instance.deviceReleaseWaitTime}"/>
                   </f:entry>
+                  <f:entry title="${%Reserve all filtered devices [experimental] }">
+                    <f:checkbox name="open-stf.enableRemoteAccessToAllFilteredDevices" checked="${instance.enableRemoteAccessToAllFilteredDevices}" tooltip="If checked, Hudson will reserve all filtered devices. This option is not compatible with android-emulator.If you choose 'Run Android monkey tester' functionality, monkey tester job will be executed only on one device"/>
+                  </f:entry>
                 </table>
               </f:block>
             </f:advanced>


### PR DESCRIPTION
This part of code give extension, to assign multiple devices to one Jenkins job run.
As is mentioned in issue #9:
https://github.com/jenkinsci/open-stf-plugin/issues/9
In this extension, there is no possibility to support usage of "Run Android monkey tester* step on multiple devices. Adding this to job it will trigger monkey tester runner only on one device. 
As workaround, you can try:
adb -s <serial> shell monkey -p my.package -c -v 500 -s "a random number"

Also this extension is only available when you select in Advance option:
![sample_view_experimental](https://user-images.githubusercontent.com/22797365/35289259-aef15508-005e-11e8-8a4d-7723ab3d650c.png)

Also for each of device, is created separate logcat file:
![result_experimental](https://user-images.githubusercontent.com/22797365/35289334-f0932932-005e-11e8-9db5-3e9023143d71.png)

Tested on STF(c953779b983a487096a6d6afe49f1cd9bcd863f7).
